### PR TITLE
add build pipeline with nob.h and hash source

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+build/
+nob
+nob.old

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "nob.h"]
+	path = nob.h
+	url = https://github.com/tsoding/nob.h

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "nob.h"]
-	path = nob.h
-	url = https://github.com/tsoding/nob.h

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 You only need a C compiler to both build and run the build system itself:
 - bootstrap
 ```bash
-gcc -o nob nob.c
+gcc -o nob nob.c -lssl -lcrypto
 ```
 - build
 ```

--- a/README.md
+++ b/README.md
@@ -1,0 +1,19 @@
+# Find all Git repositories in a directory.
+
+## Building
+`find-git-repos` is written in C, and its build system as well !
+
+You only need a C compiler to both build and run the build system itself:
+- bootstrap
+```bash
+gcc -o nob nob.c
+```
+- build
+```
+./nob
+```
+
+## Run
+```bash
+./build/main /path/to/directory
+```

--- a/nob.c
+++ b/nob.c
@@ -1,0 +1,16 @@
+#define NOB_IMPLEMENTATION
+#include "nob.h/nob.h"
+
+int main(int argc, char **argv) {
+  NOB_GO_REBUILD_URSELF(argc, argv);
+
+  Nob_Cmd cmd = {0};
+
+  nob_mkdir_if_not_exists("build/");
+
+  nob_cmd_append(&cmd, "gcc", "-O3", "-o", "build/main", "main.c");
+  if (!nob_cmd_run_sync_and_reset(&cmd))
+    return 1;
+
+  return 0;
+}

--- a/nob.c
+++ b/nob.c
@@ -28,8 +28,8 @@ int main(int argc, char **argv) {
   if (!nob_cmd_run_sync_and_reset(&cmd))
     return 1;
 
-  // hash binary
-  nob_read_entire_file(MAIN, &sb);
+  // hash source code
+  nob_read_entire_file("main.c", &sb);
   unsigned char *md_buf = malloc(SHA256_DIGEST_LENGTH);
   unsigned char *digest =
       SHA256((const unsigned char *)sb.items, sb.count, md_buf);

--- a/nob.c
+++ b/nob.c
@@ -1,5 +1,5 @@
 #define NOB_IMPLEMENTATION
-#include "nob.h/nob.h"
+#include "nob.h"
 
 int main(int argc, char **argv) {
   NOB_GO_REBUILD_URSELF(argc, argv);

--- a/nob.c
+++ b/nob.c
@@ -4,21 +4,24 @@
 #include <openssl/sha.h>
 #include <stdio.h>
 
+#define BUILD_DIR "build/"
+#define MAIN (BUILD_DIR "main")
+
 int main(int argc, char **argv) {
   NOB_GO_REBUILD_URSELF(argc, argv);
 
   Nob_Cmd cmd = {0};
   Nob_String_Builder sb = {0};
 
-  nob_mkdir_if_not_exists("build/");
+  nob_mkdir_if_not_exists(BUILD_DIR);
 
   // compile
-  nob_cmd_append(&cmd, "gcc", "-O3", "-o", "build/main", "main.c");
+  nob_cmd_append(&cmd, "gcc", "-O3", "-o", MAIN, "main.c");
   if (!nob_cmd_run_sync_and_reset(&cmd))
     return 1;
 
   // hash binary
-  nob_read_entire_file("build/main", &sb);
+  nob_read_entire_file(MAIN, &sb);
   unsigned char *md_buf = malloc(SHA256_DIGEST_LENGTH);
   unsigned char *digest =
       SHA256((const unsigned char *)sb.items, sb.count, md_buf);
@@ -29,8 +32,8 @@ int main(int argc, char **argv) {
 
   // copy
   char *dst_path = malloc(5 + 1 + 15 + SHA256_DIGEST_LENGTH * 2);
-  sprintf(dst_path, "build/find-git-repos-%s", sb.items);
-  nob_copy_file("build/main", dst_path);
+  sprintf(dst_path, (BUILD_DIR "find-git-repos-%s"), sb.items);
+  nob_copy_file(MAIN, dst_path);
 
   return 0;
 }

--- a/nob.c
+++ b/nob.c
@@ -16,7 +16,7 @@
       SHA256_DIGEST_LENGTH * 2 /* hash length, two characters per byte */
 
 int main(int argc, char **argv) {
-  NOB_GO_REBUILD_URSELF(argc, argv);
+  NOB_GO_REBUILD_URSELF_PLUS(argc, argv, NULL, "-lssl", "-lcrypto");
 
   Nob_Cmd cmd = {0};
   Nob_String_Builder sb = {0};

--- a/nob.c
+++ b/nob.c
@@ -6,6 +6,14 @@
 
 #define BUILD_DIR "build/"
 #define MAIN (BUILD_DIR "main")
+#define EXE_TEMPLATE                                                           \
+  (BUILD_DIR "find-git-repos-%s") // "%s" will be replaced with the hash of the
+                                  // executable
+#define EXE_LENGTH                                                             \
+  5 +                          /* build directory                      */      \
+      1 +                      /* path separator                       */      \
+      15 +                     /* executable name                      */      \
+      SHA256_DIGEST_LENGTH * 2 /* hash length, two characters per byte */
 
 int main(int argc, char **argv) {
   NOB_GO_REBUILD_URSELF(argc, argv);
@@ -31,9 +39,9 @@ int main(int argc, char **argv) {
   }
 
   // copy
-  char *dst_path = malloc(5 + 1 + 15 + SHA256_DIGEST_LENGTH * 2);
-  sprintf(dst_path, (BUILD_DIR "find-git-repos-%s"), sb.items);
-  nob_copy_file(MAIN, dst_path);
+  char *exe = malloc(EXE_LENGTH);
+  sprintf(exe, EXE_TEMPLATE, sb.items);
+  nob_copy_file(MAIN, exe);
 
   return 0;
 }

--- a/nob.c
+++ b/nob.c
@@ -1,16 +1,36 @@
 #define NOB_IMPLEMENTATION
 #include "nob.h"
 
+#include <openssl/sha.h>
+#include <stdio.h>
+
 int main(int argc, char **argv) {
   NOB_GO_REBUILD_URSELF(argc, argv);
 
   Nob_Cmd cmd = {0};
+  Nob_String_Builder sb = {0};
 
   nob_mkdir_if_not_exists("build/");
 
+  // compile
   nob_cmd_append(&cmd, "gcc", "-O3", "-o", "build/main", "main.c");
   if (!nob_cmd_run_sync_and_reset(&cmd))
     return 1;
+
+  // hash binary
+  nob_read_entire_file("build/main", &sb);
+  unsigned char *md_buf = malloc(SHA256_DIGEST_LENGTH);
+  unsigned char *digest =
+      SHA256((const unsigned char *)sb.items, sb.count, md_buf);
+  sb.count = 0;
+  for (int i = 0; i < SHA256_DIGEST_LENGTH; i++) {
+    nob_sb_appendf(&sb, "%02x", digest[i]);
+  }
+
+  // copy
+  char *dst_path = malloc(5 + 1 + 15 + SHA256_DIGEST_LENGTH * 2);
+  sprintf(dst_path, "build/find-git-repos-%s", sb.items);
+  nob_copy_file("build/main", dst_path);
 
   return 0;
 }

--- a/nob.h
+++ b/nob.h
@@ -544,7 +544,7 @@ bool nob_set_current_dir(const char *path);
 #       define NOB_REBUILD_URSELF(binary_path, source_path) "cl.exe", nob_temp_sprintf("/Fe:%s", (binary_path)), source_path
 #    endif
 #  else
-#    define NOB_REBUILD_URSELF(binary_path, source_path) "cc", "-o", binary_path, source_path, "-lssl", "-lcrypto"
+#    define NOB_REBUILD_URSELF(binary_path, source_path) "cc", "-o", binary_path, source_path
 #  endif
 #endif
 

--- a/nob.h
+++ b/nob.h
@@ -1,3 +1,5 @@
+// clang-format off
+
 /* nob - v1.20.2 - Public Domain - https://github.com/tsoding/nob.h
 
    This library is the next generation of the [NoBuild](https://github.com/tsoding/nobuild) idea.

--- a/nob.h
+++ b/nob.h
@@ -542,7 +542,7 @@ bool nob_set_current_dir(const char *path);
 #       define NOB_REBUILD_URSELF(binary_path, source_path) "cl.exe", nob_temp_sprintf("/Fe:%s", (binary_path)), source_path
 #    endif
 #  else
-#    define NOB_REBUILD_URSELF(binary_path, source_path) "cc", "-o", binary_path, source_path
+#    define NOB_REBUILD_URSELF(binary_path, source_path) "cc", "-o", binary_path, source_path, "-lssl", "-lcrypto"
 #  endif
 #endif
 


### PR DESCRIPTION
adds nob.h and its nob.c to compile the code
- nob.h has been modified to provide extra -l dependencies to cc
- nob.c will put the compilation artifacts of compiling main.c inside build/
- nob.c will hash the source code (main.c) being compiled to add that to the output binary
- a simple README explaining the pipeline has been added

## Commits
- **add nob.h**
- **add nob.c**
- **use nob.h directly**
- **compile with SSL and CRYPTO**
- **complete nob.c**
- **nob: define BUILD_DIR and MAIN**
- **refactor "executable" things in constants**
- **add a README**
- **complete NOB bootstrap snippet**
- **nob.h: do not format**
- **nob.h: restore (-lssl, -lcrypto)**
- **nob.h: add support for extra compilation options**
- **add -lssl and -lcrypto to nob.c**
- **hash source code instead of binary when building**
